### PR TITLE
Set node engines 6.9.0 later

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "dependencies": {
     "object-assign": "^4.1.0",
     "babel-eslint": "^7.2.1"
+  },
+  "engines": {
+    "node": ">=6.9.0"
   }
 }


### PR DESCRIPTION
Currently [hexo main repo](https://github.com/hexojs/hexo) node engine require v6.9.0 later.
So, I think it is mean that hexo supports officially 6.9.0 later. I think other official repository should set node engines same as main repo.