### PR TITLE
chore(dev-deps): update eslint to ^6.0.1

### DIFF
--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -10,7 +10,7 @@ function pagination(base, posts, options) {
   if (base && base[base.length - 1] !== '/') base += '/';
 
   const length = posts.length;
-  const perPage = options.hasOwnProperty('perPage') ? +options.perPage : 10;
+  const perPage = Object.prototype.hasOwnProperty.call(options, 'perPage') ? +options.perPage : 10;
   const total = perPage ? Math.ceil(length / perPage) : 1;
   const format = options.format || 'page/%d/';
   const layout = options.layout || ['archive', 'index'];

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^5.6.0",
+    "eslint": "^6.0.1",
     "eslint-config-hexo": "^3.0.0",
     "mocha": "^6.0.2",
     "nyc": "^14.1.1"


### PR DESCRIPTION
refactor [hasOwnProperty](https://eslint.org/docs/6.0.0/rules/no-prototype-builtins).
Closes #12 